### PR TITLE
Don't highlight syntax for code blocks w/o a specified language

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,8 @@ pages:
 
 markdown_extensions:
   - admonition
-  - codehilite(guess_lang=false)
-  - toc(permalink=true)
+  - codehilite:
+      guess_lang: False
+  - toc:
+      permalink: True
   - osg_markdown.colors

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,6 @@ pages:
 
 markdown_extensions:
   - admonition
-  - codehilite
+  - codehilite(guess_lang=false)
   - toc(permalink=true)
   - osg_markdown.colors


### PR DESCRIPTION
https://python-markdown.github.io/extensions/code_hilite/#usage

Before:

![before](https://user-images.githubusercontent.com/390105/60904611-f0015c00-a238-11e9-8a88-25c91254b71c.png)

After:

![after](https://user-images.githubusercontent.com/390105/60904623-f394e300-a238-11e9-9ecf-ffb9005d40f0.png)

As pointed out by @iross 
