### PR TITLE
cleanup in 4.2

### DIFF
--- a/docs/materials/day4/part4-ex2-mandelbrot.md
+++ b/docs/materials/day4/part4-ex2-mandelbrot.md
@@ -39,7 +39,7 @@ You can generate the Mandelbrot set as a quick test with two simple commands.
 Dividing the Work into Smaller Pieces
 -------------------------------------
 
-The Mandelbrot set can take a while to create, particularly if you make the iterations large or the image size large. What if we broke the creation of the image into multiple invocations (an HTC approach!) then stitched them together? Once we do that, we can run the each goatbroat in parallel in our cluster. Here's an example you can run by hand.
+The Mandelbrot set can take a while to create, particularly if you make the iterations large or the image size large. What if we broke the creation of the image into multiple invocations (an HTC approach!) then stitched them together? Once we do that, we can run each `goatbroat` in parallel in our cluster. Here's an example you can run by hand.
 
 1.  Run goatbroat 4 times:
 

--- a/docs/materials/day4/part4-ex2-mandelbrot.md
+++ b/docs/materials/day4/part4-ex2-mandelbrot.md
@@ -21,7 +21,7 @@ You can generate the Mandelbrot set as a quick test with two simple commands.
 1.  Generate a PPM image of the Mandelbrot set:
 
         :::console
-        username@learn $ /usr/local/bin/goatbrot -i 1000 -o tile_000000_000000.ppm -c 0,0 -w 3 -s 1000,1000
+        username@learn $ goatbrot -i 1000 -o tile_000000_000000.ppm -c 0,0 -w 3 -s 1000,1000
 
     The `goatbroat` program takes several parameters. Let's break them down:
 
@@ -44,10 +44,10 @@ The Mandelbrot set can take a while to create, particularly if you make the iter
 1.  Run goatbroat 4 times:
 
         :::console
-        username@learn $ /usr/local/bin/goatbrot -i 1000 -o tile_000000_000000.ppm -c -0.75,0.75 -w 1.5 -s 500,500
-        username@learn $ /usr/local/bin/goatbrot -i 1000 -o tile_000000_000001.ppm -c 0.75,0.75 -w 1.5 -s 500,500 
-        username@learn $ /usr/local/bin/goatbrot -i 1000 -o tile_000001_000000.ppm -c -0.75,-0.75 -w 1.5 -s 500,500 
-        username@learn $ /usr/local/bin/goatbrot -i 1000 -o tile_000001_000001.ppm -c 0.75,-0.75 -w 1.5 -s 500,500
+        username@learn $ goatbrot -i 1000 -o tile_000000_000000.ppm -c -0.75,0.75 -w 1.5 -s 500,500
+        username@learn $ goatbrot -i 1000 -o tile_000000_000001.ppm -c 0.75,0.75 -w 1.5 -s 500,500 
+        username@learn $ goatbrot -i 1000 -o tile_000001_000000.ppm -c -0.75,-0.75 -w 1.5 -s 500,500 
+        username@learn $ goatbrot -i 1000 -o tile_000001_000001.ppm -c 0.75,-0.75 -w 1.5 -s 500,500
 
 1.  Stitch the small images together into the complete image (in JPEG format):
 


### PR DESCRIPTION
* don't need absolute path for `goatbrot`
* fix some typos