### PR TITLE
Non-technical touchups for Part 4

### DIFF
--- a/docs/materials/day4/part4-ex1-simple-dag.md
+++ b/docs/materials/day4/part4-ex1-simple-dag.md
@@ -282,7 +282,7 @@ username@learn $ cat simple.log
 ...
 ```
 
-Looking at DAGMan's various files, we see that DAGMan itself ran as a Condor job (specifically, a "scheduler universe" job).
+Looking at DAGMan's various files, we see that DAGMan itself ran as a job (specifically, a "scheduler universe" job).
 
 ``` console
 username@learn $ ls simple.dag.*

--- a/docs/materials/day4/part4-ex1-simple-dag.md
+++ b/docs/materials/day4/part4-ex1-simple-dag.md
@@ -65,10 +65,10 @@ Submitting job(s).
 -----------------------------------------------------------------------
 ```
 
-In the second window, watch the queue:
+In the second window, watch the queue (what you see may be slightly different):
 
 ``` console
-username@learn $ watch -n 10 condor_q -nobatch
+username@learn $ watch -n 10 condor_q -nobatch -wide:80
 
 -- Submitter: learn.chtc.wisc.edu : <128.104.100.55:9618?sock=28867_10e4_2> : learn.chtc.wisc.edu
  ID      OWNER            SUBMITTED     RUN_TIME ST PRI SIZE CMD               
@@ -97,7 +97,7 @@ username@learn $ watch -n 10 condor_q -nobatch
 #%RED%<Ctrl-C>%ENDCOLOR%
 ```
 
-In the third window, watch what DAGMan does:
+In the third window, watch what DAGMan does (what you see may be slightly different):
 
 ``` console
 username@learn $ tail -f --lines=500 simple.dag.dagman.out
@@ -282,7 +282,7 @@ username@learn $ cat simple.log
 ...
 ```
 
-Looking at DAGMan's various files, we see that DAGMan itself ran as a Condor job (specifically, a scheduler universe job).
+Looking at DAGMan's various files, we see that DAGMan itself ran as a Condor job (specifically, a "scheduler universe" job).
 
 ``` console
 username@learn $ ls simple.dag.*
@@ -312,7 +312,7 @@ environment = _CONDOR_DAGMAN_LOG=simple.dag.dagman.out;_CONDOR_MAX_DAGMAN_LOG=0
 queue
 ```
 
-IF you want to clean up some of these files (you may not want to, at least not yet):
+If you want to clean up some of these files (you may not want to, at least not yet), run:
 
 ``` console
 username@learn $ rm simple.dag.*

--- a/docs/materials/day4/part4-ex2-mandelbrot.md
+++ b/docs/materials/day4/part4-ex2-mandelbrot.md
@@ -11,7 +11,7 @@ Before we explore using DAGs to implement workflows, let’s get a more interest
 
 We have a small program that draws pictures of the Mandelbrot set. You can [read about the Mandelbrot set on Wikipedia](https://en.wikipedia.org/wiki/Mandelbrot_set), or you can simply appreciate the pretty pictures. It’s a fractal.
 
-We have a simple program that can draw the Mandelbrot set. It's called `goatbrot`, and you can find it on most Linux servers in `/usr/local/bin/goatbrot`.
+We have a simple program that can draw the Mandelbrot set. It's called `goatbrot`.
 
 Running goatbrot From the Command Line
 --------------------------------------
@@ -54,14 +54,14 @@ The Mandelbrot set can take a while to create, particularly if you make the iter
         :::console
         username@learn $ montage tile_000000_000000.ppm tile_000000_000001.ppm tile_000001_000000.ppm tile_000001_000001.ppm -mode Concatenate -tile 2x2 mandel.jpg
 
-This will produce the same image as above. We divided the image space into a 2×2 grid and ran `goatbrot` on each section of the grid. The built-in `montage` program simply stitches the files together and writes out the final image in JPEG format.
+This will produce the same image as above. We divided the image space into a 2×2 grid and ran `goatbrot` on each section of the grid. The built-in `montage` program stitches the files together and writes out the final image in JPEG format.
 
 View the Image!
 ---------------
 
-Run the commands above, make sure you can create the Mandelbrot image. 
+Run the commands above so that you have the Mandelbrot image. 
 When you create the image, you might wonder how you can view it. 
-If you're comfortable with `scp` or another method, you can copy it back to your laptop to view it. Otherwise you can view it in your web browser in three easy steps:
+If you're comfortable with `scp` or another method, you can copy it back to your computer to view it. Otherwise you can view it in your web browser in three easy steps:
 
 1.  Make your web directory (you only need to do this once):
 
@@ -76,6 +76,6 @@ If you're comfortable with `scp` or another method, you can copy it back to your
         :::console
         username@learn $ cp mandel.jpg ~/public_html/
 
-1.  Access `http://learn.chtc.wisc.edu/~%RED%<USERNAME>%ENDCOLOR%/mandel.jpg` in your web browser (change %RED%<USERNAME>%ENDCOLOR% to your username on the submit machine).
+1.  Access `http://learn.chtc.wisc.edu/~%RED%<USERNAME>%ENDCOLOR%/mandel.jpg` in your web browser (change %RED%<USERNAME>%ENDCOLOR% to your username on `learn.chtc.wisc.edu`).
 
 

--- a/docs/materials/day4/part4-ex3-complex-dag.md
+++ b/docs/materials/day4/part4-ex3-complex-dag.md
@@ -131,10 +131,10 @@ Watch Your DAG
 
 Let’s follow the progress of the whole DAG:
 
-1.  Use the `watch` command to run `condor_q -nobatch` every 10 seconds:
+1.  Use the `watch` command to run `condor_q -nobatch -wide:80` every 10 seconds:
 
         :::console
-        username@learn $ watch -n 10 condor_q -nobatch
+        username@learn $ watch -n 10 condor_q -nobatch -wide:80
 
     %RED%**Here we see DAGMan running:**%ENDCOLOR% 
 

--- a/docs/materials/day4/part4-ex4-failed-dag.md
+++ b/docs/materials/day4/part4-ex4-failed-dag.md
@@ -250,5 +250,5 @@ Bonus Challenge
 
 If you have time, add an extra node to the DAG. Copy our original "simple" program, but make it exit with a 1 instead of a 0. DAGMan would consider this a failure, but you'll tell DAGMan that it's really a success. This is reasonable--many real world programs use a variety of return codes, and you might need to help DAGMan distinguish success from failure.
 
-Write a POST script that checks the return value. Check [the Condor manual](http://www.cs.wisc.edu/condor/manual/current/2_10DAGMan_Applications.html) to see how to describe your post script.
+Write a POST script that checks the return value. Check [the HTCondor manual](https://htcondor.readthedocs.io/en/v8_9_2/users-manual/dagman-applications.html#script) to see how to describe your post script.
 

--- a/docs/materials/day4/part4-ex5-challenges.md
+++ b/docs/materials/day4/part4-ex5-challenges.md
@@ -51,5 +51,5 @@ If you have any questions or problems, please feel free to contact the Pegasus t
 Note: Be Nice
 -------------
 
-Please be polite. Computers in our Condor pool will run multiple jobs at a time, and these computers are shared with your fellow students. If you have jobs that will use significant computational power or memory, limit your jobs to be kind to your neighbors, unless you run your jobs during off-hours.
+Please be polite. Computers in our HTCondor pool will run multiple jobs at a time, and these computers are shared with your fellow students. If you have jobs that will use significant computational power or memory, limit your jobs to be kind to your neighbors, unless you run your jobs during off-hours.
 


### PR DESCRIPTION
Wide variety of small wording changes/fixes.

Fixed one link to go to the new manual.

Most technical change is adding `-wide:80` to the `condor_q -nobatch` calls to wrangle very long `CMD` columns.