### PR TITLE
Make sure users are building on EL7 nodes

### DIFF
--- a/docs/materials/day2/part3-ex4-prepackaged.md
+++ b/docs/materials/day2/part3-ex4-prepackaged.md
@@ -47,7 +47,7 @@ Our goal is to pre-build an OpenBUGS installation, and then write a script that 
 			transfer_input_files = 
 			
 			+IsBuildJob = true
-			requirements = (IsBuildSlot == true)
+			requirements = (IsBuildSlot == true) && (OpSysMajorVer == 7)
 
 			request_cpus = 1
 			request_disk = 2GB

--- a/docs/materials/day2/part4-ex1-python-built.md
+++ b/docs/materials/day2/part4-ex1-python-built.md
@@ -157,11 +157,6 @@ Submit File
 		executable = run_fib.sh
 		transfer_input_files = fib.py, prebuilt_python.tar.gz
 
-1.  Because we pre-built our Python installation on a machine running Scientific Linux, version 6.something, we should request machines with similar characteristics. Add the following line to your submit file as well: 
-
-		:::file
-		requirements = (OpSys == "LINUX" && OpSysMajorVer == 6 )
-
 1. Submit the job using `condor_submit`. 
 
 1. Check the `.out` file to see if the job completed.

--- a/docs/materials/day3/part1-ex2-matlab.md
+++ b/docs/materials/day3/part1-ex2-matlab.md
@@ -47,7 +47,7 @@ specifically requests these build machines.
 		transfer_input_files = matrix.m
 
 		+IsBuildJob = true
-		requirements = ( IsBuildSlot == true )
+		requirements = (IsBuildSlot == true) && (OpSysMajorVer == 7)
 		request_memory = 1GB
 		request_disk = 100MB 
 


### PR DESCRIPTION
Users should build on CHTC's EL7 build machines. We still default to EL6.