### PR TITLE
Remove OpSysMajorVer requirements now that build jobs land on 7 by default

### DIFF
--- a/docs/materials/day2/part3-ex4-prepackaged.md
+++ b/docs/materials/day2/part3-ex4-prepackaged.md
@@ -47,7 +47,7 @@ Our goal is to pre-build an OpenBUGS installation, and then write a script that 
 			transfer_input_files = 
 			
 			+IsBuildJob = true
-			requirements = (IsBuildSlot == true) && (OpSysMajorVer == 7)
+			requirements = (IsBuildSlot == true)
 
 			request_cpus = 1
 			request_disk = 2GB

--- a/docs/materials/day3/part1-ex2-matlab.md
+++ b/docs/materials/day3/part1-ex2-matlab.md
@@ -47,7 +47,7 @@ specifically requests these build machines.
 		transfer_input_files = matrix.m
 
 		+IsBuildJob = true
-		requirements = (IsBuildSlot == true) && (OpSysMajorVer == 7)
+		requirements = (IsBuildSlot == true)
 		request_memory = 1GB
 		request_disk = 100MB 
 


### PR DESCRIPTION
Will submit another PR removing the "just-in-time" Python compile and run exercise.