### PR TITLE
Make it clear that the ~ in user public urls stays there

### DIFF
--- a/docs/materials/day4/part2-ex1-blast-proxy.md
+++ b/docs/materials/day4/part2-ex1-blast-proxy.md
@@ -30,7 +30,7 @@ user@training $ cp pdbaa_files.tar.gz ~/stash/public/
 
 Once the file is placed in the `~/stash/public` directory, it can be downloaded from a corresponding URL such as
 `http://stash.osgconnect.net/~<USERNAME>/pdbaa_files.tar.gz`, where `<USERNAME>` is your username on
-`training.osgconnect.net`.
+`training.osgconnect.net` (make sure to keep the `~` before your username!).
 
 Using the above convention (and from a different directory on `training.osgconnect.net`, any directory), you can test
 the download of your `pdbaa_files.tar.gz` file with a command like the following:

--- a/docs/materials/day4/part2-ex1-blast-proxy.md
+++ b/docs/materials/day4/part2-ex1-blast-proxy.md
@@ -39,7 +39,7 @@ the download of your `pdbaa_files.tar.gz` file with a command like the following
 user@training $ wget http://stash.osgconnect.net/~<USERNAME>/pdbaa_files.tar.gz
 ```
 
-Replacing `<USERNAME>` with your own username.
+Replacing `<USERNAME>` with your own username (but keep the `~`!).
 You may realize that you've been using `wget` to download files from a web proxy for many of the previous exercises at
 the school!
 

--- a/docs/materials/day4/part4-ex2-mandelbrot.md
+++ b/docs/materials/day4/part4-ex2-mandelbrot.md
@@ -76,6 +76,6 @@ If you're comfortable with `scp` or another method, you can copy it back to your
         :::console
         username@learn $ cp mandel.jpg ~/public_html/
 
-1.  Access `http://learn.chtc.wisc.edu/~%RED%<USERNAME>%ENDCOLOR%/mandel.jpg` in your web browser (change %RED%<USERNAME>%ENDCOLOR% to your username on `learn.chtc.wisc.edu`).
+1.  Access `http://learn.chtc.wisc.edu/~%RED%<USERNAME>%ENDCOLOR%/mandel.jpg` in your web browser (change %RED%<USERNAME>%ENDCOLOR% to your username on `learn.chtc.wisc.edu`, keeping the `~`).
 
 


### PR DESCRIPTION
lots of people are deleting it along with the `<USERNAME>` bit