### PR TITLE
Day 4 Part 4: OpSysMajorVer requirements no longer needed

### DIFF
--- a/docs/materials/day4/part4-ex3-complex-dag.md
+++ b/docs/materials/day4/part4-ex3-complex-dag.md
@@ -86,7 +86,6 @@ log                     = montage.log
 request_memory          = 1GB
 request_disk            = 1GB
 request_cpus            = 1
-requirements            = OpSysMajorVer =?= 7
 queue
 ```
 

--- a/docs/materials/day4/part4-ex4-failed-dag.md
+++ b/docs/materials/day4/part4-ex4-failed-dag.md
@@ -27,7 +27,6 @@ log                     = montage.log
 request_memory          = 1GB
 request_disk            = 1GB
 request_cpus            = 1
-requirements            = OpSysMajorVer =?= 6
 queue
 ```
 
@@ -130,7 +129,6 @@ log                     = montage.log
 request_memory          = 1GB
 request_disk            = 1GB
 request_cpus            = 1
-requirements            = OpSysMajorVer =?= 6
 queue
 ```
 


### PR DESCRIPTION
Won't hurt to have them, but not needed anymore.